### PR TITLE
fix: update pipeline template version to latest [1]

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,1 +1,1 @@
-template: screwdriver-cd-test/test-pipeline-template@1.0.1
+template: screwdriver-cd-test/test-pipeline-template@latest

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,1 +1,1 @@
-template: screwdriver-cd-test/test-pipeline-template@1.0.0
+template: screwdriver-cd-test/test-pipeline-template@1.0.1


### PR DESCRIPTION
Update the pipeline template version to latest because the 1.0.0 template is corrupted.
Specifically, environment variables and images are empty on the DB.

Also, the versions of prod and beta do not match, so I have set it to “latest”.

https://cd.screwdriver.cd/templates/pipeline/screwdriver-cd-test/test-pipeline-template/1.0.1
https://beta.cd.screwdriver.cd/templates/pipeline/screwdriver-cd-test/test-pipeline-template/1.0.2